### PR TITLE
Pluggable storage backends system

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -65,6 +65,6 @@ config :crawly,
 config :crawly, Crawly.DataStorage.FileStorageBackend,
   folder: "/tmp",
   include_headers: false,
-  extension: "jl"
+  extension: "csv"
 
 import_config "#{Mix.env}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -32,8 +32,6 @@ use Mix.Config
 config :crawly, Crawly.Worker, client: HTTPoison
 
 config :crawly,
-  # The path where items are stored
-  base_store_path: "/tmp/",
   # User agents which are going to be used with requests
   user_agents: [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0",
@@ -47,6 +45,7 @@ config :crawly,
   # Stop spider after scraping certain amount of items
   closespider_itemcount: 500,
   # Stop spider if it does crawl fast enough
+  storage_backend: Crawly.DataStorage.FileStorageBackend,
   closespider_timeout: 20,
   concurrent_requests_per_domain: 5,
   follow_redirects: true,
@@ -60,7 +59,12 @@ config :crawly,
   pipelines: [
     Crawly.Pipelines.Validate,
     Crawly.Pipelines.DuplicatesFilter,
-    Crawly.Pipelines.JSONEncoder
+    Crawly.Pipelines.CSVEncoder
   ]
 
- import_config "#{Mix.env}.exs"
+config :crawly, Crawly.DataStorage.FileStorageBackend,
+  folder: "/tmp",
+  include_headers: false,
+  extension: "jl"
+
+import_config "#{Mix.env}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,35 +1,39 @@
 use Mix.Config
 
 config :crawly,
-  manager_operations_timeout: 30_000,
+       manager_operations_timeout: 30_000,
 
-  # The path where items are stored
-  base_store_path: "/tmp/",
-  # User agents which are going to be used with requests
-  user_agents: [
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41"
-  ],
-  # Item definition
-  item: [:title, :author, :time, :url],
-  # Identifier which is used to filter out duplicates
-  item_id: :title,
-  # Stop spider after scraping certain amount of items
-  closespider_itemcount: 100,
-  # Stop spider if it does crawl fast enough
-  closespider_timeout: 20,
-  concurrent_requests_per_domain: 5,
-  follow_redirects: true,
-  # Request middlewares
-  middlewares: [
-    Crawly.Middlewares.DomainFilter,
-    Crawly.Middlewares.UniqueRequest,
-    Crawly.Middlewares.RobotsTxt,
-    Crawly.Middlewares.UserAgent
-  ],
-  pipelines: [
-    Crawly.Pipelines.Validate,
-    Crawly.Pipelines.DuplicatesFilter,
-    Crawly.Pipelines.JSONEncoder
-  ]
+         # User agents which are going to be used with requests
+       user_agents: [
+         "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0",
+         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36",
+         "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41"
+       ],
+         # Item definition
+       item: [:title, :author, :time, :url],
+       storage_backend: Crawly.DataStorage.CSVFileStorageBackend,
+         # Identifier which is used to filter out duplicates
+       item_id: :title,
+         # Stop spider after scraping certain amount of items
+       closespider_itemcount: 100,
+         # Stop spider if it does crawl fast enough
+       closespider_timeout: 20,
+       concurrent_requests_per_domain: 5,
+       follow_redirects: true,
+         # Request middlewares
+       middlewares: [
+         Crawly.Middlewares.DomainFilter,
+         Crawly.Middlewares.UniqueRequest,
+         Crawly.Middlewares.RobotsTxt,
+         Crawly.Middlewares.UserAgent
+       ],
+       storage_backend: Crawly.DataStorage.FileStorageBackend,
+       pipelines: [
+         Crawly.Pipelines.Validate,
+         Crawly.Pipelines.DuplicatesFilter,
+         Crawly.Pipelines.JSONEncoder
+       ]
+config :crawly, Crawly.DataStorage.FileStorageBackend,
+       folder: "/tmp",
+       include_headers: false,
+       extension: "jl"

--- a/docs/README.md
+++ b/docs/README.md
@@ -728,7 +728,7 @@ config :crawly,
   # Item definition
   item: [:title, :author, :time, :url],
   # Identifier which is used to filter out duplicates
-  item_id: :title,
+  item_id: :title
 ```
 
 ### base_store_path :: binary()

--- a/lib/crawly/data_storage/backends/dev_null_storage_backend.ex
+++ b/lib/crawly/data_storage/backends/dev_null_storage_backend.ex
@@ -1,0 +1,29 @@
+defmodule Crawly.DataStorage.DevNullStorageBackend do
+  @moduledoc """
+  Implements Crawly.DataStorage.StorageBackend behaviour, which does not actually
+  store any item
+  """
+  @behaviour Crawly.DataStorage.StorageBackend
+
+  require Logger
+
+  @spec init(spider_name) :: {:ok, :null} when
+          spider_name: atom()
+  def init(_spider_name) do
+    {:ok, :null}
+  end
+
+  @doc """
+  Implements a write callback which just ignores item
+  """
+  @spec write(io, item) :: :ok when
+          io: atom(),
+          item: any()
+  def write(_io, _item), do: :ok
+
+  @doc """
+  Closes the io_device
+  """
+  @spec close(atom()) :: :ok
+  def close(:null), do: :ok
+end

--- a/lib/crawly/data_storage/backends/file_storage_backend.ex
+++ b/lib/crawly/data_storage/backends/file_storage_backend.ex
@@ -1,0 +1,90 @@
+defmodule Crawly.DataStorage.FileStorageBackend do
+  @moduledoc """
+  Implements Crawly.DataStorage.StorageBackend behaviour
+  """
+  @behaviour Crawly.DataStorage.StorageBackend
+  require Logger
+
+  @doc """
+  Opens a file in a delayed_write mode (so writing is not going to be blocking)
+  and returns {:ok, io_device()} as a result.
+  """
+  @spec init(spider_name) :: {:ok, File.io_device()} when
+          spider_name: atom()
+  def init(spider_name) do
+    config = Application.get_env(
+      :crawly,
+      Crawly.DataStorage.FileStorageBackend,
+      Keyword.new()
+    )
+
+    folder = Keyword.get(config, :folder, "/tmp")
+    extension = Keyword.get(config, :extension, "txt")
+
+    filename = "#{inspect(spider_name)}.#{extension}"
+    full_path = Path.join([folder, filename])
+
+    # Open file descriptor to write items
+    {:ok, io_device} =
+      File.open(
+        full_path,
+        [
+          :binary,
+          :write,
+          :delayed_write,
+          :utf8
+        ]
+      )
+
+    # Include headers into the output. For now the headers are taken from item
+    # description.
+    case Keyword.get(config, :include_headers, false) do
+      false ->
+        :ok
+
+      true ->
+        headers = Enum.map(
+          Application.get_env(:crawly, :item),
+          &Atom.to_string/1
+        )
+        converted_headers = Crawly.Utils.list_to_csv(
+          headers,
+          :maps.from_list(Enum.zip(headers, headers))
+        )
+        :ok = write(io_device, converted_headers)
+    end
+    {:ok, io_device}
+  end
+
+  @doc """
+  Implements a write callback for a JLFileStorageBackend
+  """
+  @spec write(io, item) :: :ok when
+          io: File.io_device(),
+          item: any()
+  def write(io, item) do
+    try do
+      IO.write(io, item)
+      IO.write(io, "\n")
+    catch
+      error, reason ->
+        stacktrace = :erlang.get_stacktrace()
+
+        Logger.error(
+          "Could not write item: #{inspect(error)}, reason: #{
+            inspect(reason)
+          }, stacktrace: #{
+            inspect(stacktrace)
+          }
+          "
+        )
+    end
+  end
+
+  @doc """
+  Closes the io_device
+  """
+  @spec close(io) :: :ok
+        when io: File.io_device()
+  def close(io), do: File.close(io)
+end

--- a/lib/crawly/data_storage/backends/file_storage_backend.ex
+++ b/lib/crawly/data_storage/backends/file_storage_backend.ex
@@ -57,7 +57,7 @@ defmodule Crawly.DataStorage.FileStorageBackend do
   end
 
   @doc """
-  Implements a write callback for a JLFileStorageBackend
+  Implements the write callback for storage backend
   """
   @spec write(io, item) :: :ok when
           io: File.io_device(),

--- a/lib/crawly/data_storage/storage_backend.ex
+++ b/lib/crawly/data_storage/storage_backend.ex
@@ -1,0 +1,14 @@
+defmodule Crawly.DataStorage.StorageBackend do
+
+  @callback init(spider_name) :: {:ok, maybe_io_device}
+            when spider_name: atom(),
+                 maybe_io_device: File.io_device() | atom()
+
+  @callback write(item, maybe_io_device) :: :ok
+            when item: any(),
+                 maybe_io_device: File.io_device() | atom()
+
+  @callback close(maybe_io_device) :: :ok
+            when maybe_io_device: File.io_device() | atom()
+
+end

--- a/lib/crawly/pipelines/csv_encoder.ex
+++ b/lib/crawly/pipelines/csv_encoder.ex
@@ -10,17 +10,8 @@ defmodule Crawly.Pipelines.CSVEncoder do
       :undefined ->
         {false, state}
 
-      fields ->
-        new_item =
-          Enum.reduce(fields, "", fn
-            field, "" ->
-              "#{inspect(Map.get(item, field, ""))}"
-
-            field, acc ->
-              acc <> "," <> "#{inspect(Map.get(item, field, ""))}"
-          end)
-
-        {new_item, state}
+      headers ->
+        {Crawly.Utils.list_to_csv(headers, item), state}
     end
   end
 end

--- a/lib/crawly/utils.ex
+++ b/lib/crawly/utils.ex
@@ -21,7 +21,8 @@ defmodule Crawly.Utils do
   """
   @spec build_absolute_url(binary(), binary()) :: binary()
   def build_absolute_url(url, base_url) do
-    URI.merge(base_url, url) |> to_string()
+    URI.merge(base_url, url)
+    |> to_string()
   end
 
   @doc """
@@ -29,7 +30,12 @@ defmodule Crawly.Utils do
   """
   @spec build_absolute_urls([binary()], binary()) :: [binary()]
   def build_absolute_urls(urls, base_url) do
-    Enum.map(urls, fn url -> URI.merge(base_url, url) |> to_string() end)
+    Enum.map(
+      urls,
+      fn url ->
+        URI.merge(base_url, url)
+        |> to_string() end
+    )
   end
 
   @doc """
@@ -76,5 +82,21 @@ defmodule Crawly.Utils do
       end
 
     pipe(pipelines, new_item, new_state)
+  end
+
+  @doc """
+  Convert a list into a CSV values. [title, url] -> "title,url"
+  """
+  @spec list_to_csv(headers, item) :: binary()
+        when headers: [],
+             item: map()
+  def list_to_csv(headers, item) do
+    Enum.reduce(
+      headers, "",
+      fn
+        header, "" -> "#{inspect(Map.get(item, header, ""))}"
+        header, acc -> acc <> "," <> "#{inspect(Map.get(item, header, ""))}"
+      end
+    )
   end
 end


### PR DESCRIPTION
This commit introduces a pluggable backends, and simplifies the storing logic
inside Crawly. Now it's possible to extend storage with additional backends (like S3)

At this point I have checked in the FileStorageBackend and DevNullStorageBackends