### PR TITLE
Pipe adjustments to handle tuple-based declarations for pipelines and middlewares

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -6,10 +6,12 @@ A basic example:
 
 ```elixir
 config :crawly,
-  # Item definition
-  item: [:title, :author, :time, :url],
-  # Identifier which is used to filter out duplicates
-  item_id: :title
+  pipelines: [
+    # my pipelines
+  ]
+  middlewares: [
+    # my middlewares
+  ]
 ```
 
 ## Options
@@ -32,6 +34,8 @@ by the `Crawly.Middlewares.UserAgent` middleware. When the list has more than on
 item, all requests will be executed, each with a user agent string chosen
 randomly from the supplied list.
 
+> **Deprecated**: This has been deprecated in favour of tuple-based pipeline configuration instead of global configurations, as of `0.7.0`. Refer to `Crawly.Middlewares.UserAgent` module documentation for correct usage.
+
 ### `item` :: [atom()]
 
 default: []
@@ -40,6 +44,8 @@ Defines a list of required fields for the item. When none of the default
 fields are added to the following item (or if the values of
 required fields are "" or nil), the item will be dropped. This setting
 is used by the `Crawly.Pipelines.Validate` pipeline
+
+> **Deprecated**: This has been deprecated in favour of tuple-based pipeline configuration instead of global configurations, as of `0.7.0`. Refer to `Crawly.Pipelines.Validate` module documentation for correct usage.
 
 ### `item_id` :: atom()
 
@@ -50,6 +56,8 @@ a duplicate or not. In most of the ecommerce websites the desired id
 field is the SKU. This setting is used in
 the `Crawly.Pipelines.DuplicatesFilter` pipeline. If unset, the related
 middleware is effectively disabled.
+
+> **Deprecated**: This has been deprecated in favour of tuple-based pipeline configuration instead of global configurations, as of `0.7.0`. Refer to `Crawly.Pipelines.DuplicatesFilter` module documentation for correct usage.
 
 ### `pipelines` :: [module()]
 
@@ -62,21 +70,25 @@ Example configuration of item pipelines:
 ```
 config :crawly,
   pipelines: [
-    Crawly.Pipelines.Validate,
-    Crawly.Pipelines.DuplicatesFilter,
+    {Crawly.Pipelines.Validate, fields: [:id, :date]},
+    {Crawly.Pipelines.DuplicatesFilter, item_id: :id},
     Crawly.Pipelines.JSONEncoder,
-    Crawly.Pipelines.WriteToFile # NEW IN 0.6.0
+    {Crawly.Pipelines.WriteToFile, extension: "jl", folder: "/tmp"} # NEW IN 0.6.0
     ]
 ```
 
 ### middlewares :: [module()]
 
-default: [
-Crawly.Middlewares.DomainFilter,
-Crawly.Middlewares.UniqueRequest,
-Crawly.Middlewares.RobotsTxt,
-Crawly.Middlewares.UserAgent
-]
+```elixir
+The default middlewares are as follows:
+config :crawly,
+  middlewares: [
+    Crawly.Middlewares.DomainFilter,
+    Crawly.Middlewares.UniqueRequest,
+    Crawly.Middlewares.RobotsTxt,
+    {Crawly.Middlewares.UserAgent, user_agents: ["My Bot"] }
+  ]
+```
 
 Defines a list of middlewares responsible for pre-processing requests. If any of the requests from the `Crawly.Spider` is not passing the middleware, it's dropped.
 

--- a/documentation/quickstart.md
+++ b/documentation/quickstart.md
@@ -58,19 +58,16 @@ Goals:
      concurrent_requests_per_domain: 8,
      follow_redirects: true,
      closespider_itemcount: 1000,
-     output_format: "csv",
-     item: [:title, :url],
-     item_id: :title,
      middlewares: [
        Crawly.Middlewares.DomainFilter,
        Crawly.Middlewares.UniqueRequest,
        Crawly.Middlewares.UserAgent
      ],
      pipelines: [
-       Crawly.Pipelines.Validate,
-       Crawly.Pipelines.DuplicatesFilter,
-       Crawly.Pipelines.CSVEncoder,
-       Crawly.Pipelines.WriteToFile
+       {Crawly.Pipelines.Validate, fields: [:title, :url]},
+       {Crawly.Pipelines.DuplicatesFilter, item_id: :title },
+       {Crawly.Pipelines.CSVEncoder, fields: [:title, :url}],
+       {Crawly.Pipelines.WriteToFile, extension: "csv", folder: "/tmp" }
      ]
    ```
 5. Start the Crawl:

--- a/lib/crawly/middlewares/domain_filter.ex
+++ b/lib/crawly/middlewares/domain_filter.ex
@@ -1,12 +1,23 @@
 defmodule Crawly.Middlewares.DomainFilter do
   @moduledoc """
-  Filters out requests which are going outside of the crawled domain
+  Filters out requests which are going outside of the crawled domain.
+
+  The domain that is used to compare against the request url is obtained from the spider's `c:Crawly.Spider.base_url` callback.
+
+  Does not accept any options. Tuple-based configuration optionswill be ignored.
+
+  ### Example Declaration
+  ```
+  middlewares: [
+    Crawly.Middlewares.DomainFilter
+  ]
+  ```
   """
 
   @behaviour Crawly.Pipeline
   require Logger
 
-  def run(request, state) do
+  def run(request, state, _opts \\ []) do
     base_url = state.spider_name.base_url()
 
     case String.contains?(request.url, base_url) do

--- a/lib/crawly/middlewares/robotstxt.ex
+++ b/lib/crawly/middlewares/robotstxt.ex
@@ -6,20 +6,24 @@ defmodule Crawly.Middlewares.RobotsTxt do
   crawler can or can't request from your site. This is used mainly to avoid
   overloading a site with requests!
 
-  Please NOTE:
-  The first rule of web crawling is you do not harm the website.
-  The second rule of web crawling is you do NOT harm the website
+  No options are required for this middleware. Any tuple-based configurations options passed will be ignored.
+
+
+  ### Example Declaration
+  ```
+  middlewares: [
+    Crawly.Middlewares.RobotsTxt
+  ]
+  ```
   """
 
   @behaviour Crawly.Pipeline
   require Logger
 
-  def run(request, state) do
+  def run(request, state, _opts \\ []) do
     case Gollum.crawlable?("Crawly", request.url) do
       :uncrawlable ->
-        Logger.debug(
-          "Dropping request: #{request.url} (robots.txt filter)"
-        )
+        Logger.debug("Dropping request: #{request.url} (robots.txt filter)")
 
         {false, state}
 

--- a/lib/crawly/middlewares/user_agent.ex
+++ b/lib/crawly/middlewares/user_agent.ex
@@ -4,16 +4,34 @@ defmodule Crawly.Middlewares.UserAgent do
   :crawly, :user_agents sessions.
 
   The default value for the user agent is: Crawly Bot 1.0
+
+  Rotation is determined through `Enum.random/1`.
+  ### Options
+  - `:user_agents`, optional. A list of user agent strings to rotate. Defaults to "Crawly Bot 1.0".
+
+  ### Example Declaration
+  ```
+  middlewares: [
+    {UserAgent, user_agents: ["My Custom Bot] }
+  ]
+  ```
   """
   require Logger
 
-  def run(request, state) do
+  def run(request, state, opts \\ []) do
+    opts = Enum.into(opts, %{user_agents: nil})
+
     new_headers = List.keydelete(request.headers, "User-Agent", 0)
-    user_agents = Application.get_env(:crawly, :user_agents, ["Crawly Bot 1.0"])
+
+    user_agents =
+      Map.get(opts, :user_agents) ||
+        Application.get_env(:crawly, :user_agents, ["Crawly Bot 1.0"])
+
     useragent = Enum.random(user_agents)
 
     new_request =
       Map.put(request, :headers, [{"User-Agent", useragent} | new_headers])
+
     {new_request, state}
   end
 end

--- a/lib/crawly/pipeline.ex
+++ b/lib/crawly/pipeline.ex
@@ -5,10 +5,17 @@ defmodule Crawly.Pipeline do
   A pipeline is a module which takes a given item, and executes a
   run callback on a given item.
 
-  A state variable is used to share common information accros multiple
+  A state argument is used to share common information accros multiple
   items.
+
+  An `opts` argument is used to pass configuration to the pipeline through tuple-based declarations.
   """
   @callback run(item :: map, state :: map()) ::
               {new_item :: map, new_state :: map}
               | {false, new_state :: map}
+
+  @callback run(item :: map, state :: map(), args :: list(any())) ::
+              {new_item :: map, new_state :: map}
+              | {false, new_state :: map}
+  @optional_callbacks run: 3
 end

--- a/lib/crawly/pipelines/json_encoder.ex
+++ b/lib/crawly/pipelines/json_encoder.ex
@@ -1,13 +1,28 @@
 defmodule Crawly.Pipelines.JSONEncoder do
   @moduledoc """
   Encodes a given item (map) into JSON
+
+  No options are available for this pipeline.
+
+  ### Example Declaration
+  ```
+  pipelines: [
+    Crawly.Pipelines.JSONEncoder
+  ]
+  ```
+
+  ### Example Usage
+  ```
+    iex> JSONEncoder.run(%{my: "field"}, %{})
+    {"{\"my\":\"field\"}", %{}}
+  ```
   """
   @behaviour Crawly.Pipeline
 
   require Logger
 
   @impl Crawly.Pipeline
-  def run(item, state) do
+  def run(item, state, _opts \\ []) do
     case Poison.encode(item) do
       {:ok, new_item} ->
         {new_item, state}

--- a/lib/crawly/pipelines/validate.ex
+++ b/lib/crawly/pipelines/validate.ex
@@ -1,14 +1,33 @@
 defmodule Crawly.Pipelines.Validate do
   @moduledoc """
-  Ensure that scraped item contains all fields defined in config: item.
+  Ensure that scraped item contains a set of required fields.
+
+  ### Options
+  If the fields to check are not provided, the pipeline does nothing.
+  - `:fields`, required: The list of required fields. Fallsback to global config `:item`.
+
+  ### Example Declaration
+  ```
+  pipelines: [
+    {Crawly.Pipelines.Validate, fields: [:id, :url, :date]}
+  ]
+  ```
+
+  ### Example Usage
+  ```
+  # Drops the scraped item that does not have the required fields
+  iex> Validate.run(%{my: "field"}, %{}, fields: [:id])
+  {false, %{}}
+  ```
   """
   @behaviour Crawly.Pipeline
 
   require Logger
 
   @impl Crawly.Pipeline
-  def run(item, state) do
-    fields = Application.get_env(:crawly, :item, [])
+  def run(item, state, opts \\ []) do
+    opts = Enum.into(opts, %{fields: nil})
+    fields = Map.get(opts, :fields) || Application.get_env(:crawly, :item, [])
 
     validation_result =
       fields

--- a/test/middlewares/domain_filter_test.exs
+++ b/test/middlewares/domain_filter_test.exs
@@ -1,0 +1,21 @@
+defmodule Middlewares.DomainFilterTest do
+  use ExUnit.Case, async: false
+
+  @valid %Crawly.Request{url: "https://www.some_url.com"}
+  setup do
+    :meck.new(:test_spider, [:non_strict])
+    :meck.expect(:test_spider, :base_url, fn -> "example.com" end)
+
+    on_exit(fn ->
+      Application.put_env(:crawly, :item_id, :title)
+    end)
+  end
+
+  test "Filters out requests that do not contain a spider's base_url" do
+    middlewares = [Crawly.Middlewares.DomainFilter]
+    req = @valid
+    state = %{spider_name: :test_spider}
+
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
+end

--- a/test/middlewares/robotstxt_test.exs
+++ b/test/middlewares/robotstxt_test.exs
@@ -1,0 +1,20 @@
+defmodule Middlewares.RobotsTxtTest do
+  use ExUnit.Case, async: false
+
+  @valid %Crawly.Request{url: "https://www.some_url.com/my_site"}
+  setup do
+    on_exit(fn ->
+      :meck.unload()
+    end)
+  end
+
+  test "Filters out requests that are not permitted by robots.txt" do
+    :meck.expect(Gollum, :crawlable?, fn _ua, _url -> :uncrawlable end)
+
+    middlewares = [Crawly.Middlewares.RobotsTxt]
+    req = @valid
+    state = %{spider_name: :test_spider}
+
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
+end

--- a/test/middlewares/unique_request_test.exs
+++ b/test/middlewares/unique_request_test.exs
@@ -1,0 +1,15 @@
+defmodule Middlewares.UniqueRequestTest do
+  use ExUnit.Case, async: false
+
+  @valid %Crawly.Request{url: "https://www.some_url.com"}
+
+  test "Filters out requests non-unique urls" do
+    middlewares = [Crawly.Middlewares.UniqueRequest]
+    req = @valid
+    state = %{spider_name: :test_spider}
+
+    assert {_req, state} = Crawly.Utils.pipe(middlewares, req, state)
+    # run again, should drop the request
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
+end

--- a/test/middlewares/user_agent_test.exs
+++ b/test/middlewares/user_agent_test.exs
@@ -1,0 +1,41 @@
+defmodule Middlewares.UserAgentTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    on_exit(fn ->
+      Application.put_env(:crawly, :user_agents, nil)
+    end)
+  end
+
+  test "Adds a user agent to request header with global config" do
+    Application.put_env(:crawly, :user_agents, ["My Custom Bot"])
+    middlewares = [Crawly.Middlewares.UserAgent]
+    req = %Crawly.Request{}
+    state = %{}
+
+    {req, _state} = Crawly.Utils.pipe(middlewares, req, state)
+
+    {_, ua} =
+      Map.get(req, :headers)
+      |> Enum.find(fn {name, _value} -> name == "User-Agent" end)
+
+    assert ua == "My Custom Bot"
+  end
+
+  test "Adds a user agent to request header with tuple config" do
+    middlewares = [
+      {Crawly.Middlewares.UserAgent, user_agents: ["My Custom Bot"]}
+    ]
+
+    req = %Crawly.Request{}
+    state = %{}
+
+    {req, _state} = Crawly.Utils.pipe(middlewares, req, state)
+
+    {_, ua} =
+      Map.get(req, :headers)
+      |> Enum.find(fn {name, _value} -> name == "User-Agent" end)
+
+    assert ua == "My Custom Bot"
+  end
+end

--- a/test/pipelines/csv_encoder_test.exs
+++ b/test/pipelines/csv_encoder_test.exs
@@ -8,10 +8,21 @@ defmodule Pipelines.CSVEncoderTest do
     end)
   end
 
-  test "Converts a single-level map to a csv string" do
+  test "Converts a single-level map to a csv string with global config" do
     Application.put_env(:crawly, :item, [:first, :second])
 
     pipelines = [Crawly.Pipelines.CSVEncoder]
+    item = @valid
+    state = %{}
+
+    {item, _state} = Crawly.Utils.pipe(pipelines, item, state)
+
+    assert is_binary(item)
+    assert item == ~S("some","data")
+  end
+
+  test "Converts a single-level map to a csv string with tuple config" do
+    pipelines = [{Crawly.Pipelines.CSVEncoder, fields: [:first, :second]}]
     item = @valid
     state = %{}
 

--- a/test/pipelines/duplicates_filter_test.exs
+++ b/test/pipelines/duplicates_filter_test.exs
@@ -8,9 +8,25 @@ defmodule Pipelines.DuplicatesFilterTest do
     end)
   end
 
-  test "Drops duplicate items with the same item_id value" do
+  test "Drops duplicate items with the same item_id value through global config" do
     Application.put_env(:crawly, :item_id, :id)
     pipelines = [Crawly.Pipelines.DuplicatesFilter]
+    item = @valid
+    state = %{}
+
+    {item, state} = Crawly.Utils.pipe(pipelines, item, state)
+
+    # filter state is updated
+    assert %{"my_id" => true} = state.duplicates_filter
+    # unchanged
+    assert item == @valid
+
+    # run again with same item and updated state should drop the item
+    assert {false, state} = Crawly.Utils.pipe(pipelines, item, state)
+  end
+
+  test "Drops duplicate items with the same item_id value through tuple config" do
+    pipelines = [{Crawly.Pipelines.DuplicatesFilter, item_id: :id}]
     item = @valid
     state = %{}
 

--- a/test/pipelines/validate_test.exs
+++ b/test/pipelines/validate_test.exs
@@ -29,9 +29,17 @@ defmodule Pipelines.ValidateTest do
     assert item == @valid
   end
 
-  test "Drops items when missing required fields" do
+  test "Drops items when missing required fields with global config" do
     Application.put_env(:crawly, :item, [:title, :author])
     pipelines = [Crawly.Pipelines.Validate]
+    item = @invalid_missing
+    state = %{}
+
+    {false, _state} = Crawly.Utils.pipe(pipelines, item, state)
+  end
+
+  test "Drops items when missing required fields with tuple config" do
+    pipelines = [{Crawly.Pipelines.Validate, fields: [:title, :author]}]
     item = @invalid_missing
     state = %{}
 

--- a/test/pipelines/write_to_file_test.exs
+++ b/test/pipelines/write_to_file_test.exs
@@ -4,21 +4,30 @@ defmodule Pipelines.WriteToFileTest do
   @binary "Some binary"
 
   setup do
-    on_exit(
-      fn ->
-        Application.put_env(:crawly, :'Crawly.Pipelines.WriteToFile', nil)
-      end
-    )
+    on_exit(fn ->
+      Application.put_env(:crawly, :"Crawly.Pipelines.WriteToFile", nil)
+      :meck.unload(IO)
+      :meck.unload(File)
+    end)
   end
 
-  test "Writes a given item to a file", _context do
+  test "Writes a given item to a file with global config", _context do
     test_pid = self()
+
     :meck.expect(
       IO,
       :write,
-      fn (_, item) ->
+      fn _, item ->
         send(test_pid, item)
         :ok
+      end
+    )
+
+    :meck.expect(
+      File,
+      :open,
+      fn _path, _opts ->
+        {:ok, test_pid}
       end
     )
 
@@ -38,8 +47,41 @@ defmodule Pipelines.WriteToFileTest do
     state = %{spider_name: MySpider}
 
     # run the pipeline
-    _result =
-      Crawly.Utils.pipe(pipelines, item, state)
+    _result = Crawly.Utils.pipe(pipelines, item, state)
+
+    assert_receive @binary
+  end
+
+  test "Writes a given item to a file with tuple config", _context do
+    test_pid = self()
+
+    :meck.expect(
+      IO,
+      :write,
+      fn _, item ->
+        send(test_pid, item)
+        :ok
+      end
+    )
+
+    :meck.expect(
+      File,
+      :open,
+      fn _path, _opts ->
+        {:ok, test_pid}
+      end
+    )
+
+    pipelines = [
+      {Crawly.Pipelines.WriteToFile, folder: "/tmp", extension: "csv"}
+    ]
+
+    item = @binary
+
+    state = %{spider_name: MySpider}
+
+    # run the pipeline
+    _result = Crawly.Utils.pipe(pipelines, item, state)
 
     assert_receive @binary
   end


### PR DESCRIPTION
todos:

- [x]  update pipelines and corresponding tests once #29 is merged
    - [x] WriteToFile pipeline remaining

- [x] update middlewares and corresponding tests

- [x] add custom middleware example

- [ ] logger warn users that are still using global env declaration, show example of correct tuple declation w/ example
- [x] update user docs, deprecation warning for global configs, quickstart
- [x] update dev docs, doc for `Crawly.Utils.pipe`, best prac for handling pipeline arguments

related to #22 