### PR TITLE
Add retries support

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -33,7 +33,7 @@ config :crawly, Crawly.Worker, client: HTTPoison
 
 config :crawly,
   fetcher: {Crawly.Fetchers.HTTPoisonFetcher, []},
-
+  max_retries: 3,
   # User agents which are going to be used with requests
   user_agents: [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0",

--- a/config/config.exs
+++ b/config/config.exs
@@ -33,7 +33,9 @@ config :crawly, Crawly.Worker, client: HTTPoison
 
 config :crawly,
   fetcher: {Crawly.Fetchers.HTTPoisonFetcher, []},
-  max_retries: 3,
+  retry: [
+    {:max_retries, 3},
+    {:ignored_middlewares, [Crawly.Middlewares.UniqueRequest]}],
   # User agents which are going to be used with requests
   user_agents: [
     "Mozilla/5.0 (Macintosh; Intel Mac OS X x.y; rv:42.0) Gecko/20100101 Firefox/42.0",
@@ -63,8 +65,9 @@ config :crawly,
     Crawly.Pipelines.JSONEncoder
   ]
 
-config :crawly, Crawly.Pipelines.WriteToFile,
-  folder: "/tmp",
-  extension: "jl"
+config :crawly,
+       Crawly.Pipelines.WriteToFile,
+       folder: "/tmp",
+       extension: "jl"
 
- import_config "#{Mix.env}.exs"
+import_config "#{Mix.env}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,11 @@ config :crawly,
   item: [:title, :author, :time, :url],
   # Identifier which is used to filter out duplicates
   item_id: :title,
-  max_retries: 2,
+
+  retry: [
+    {:max_retries, 2},
+    {:ignored_middlewares, [Crawly.Middlewares.UniqueRequest]}
+  ],
   # Stop spider after scraping certain amount of items
   closespider_itemcount: 100,
   # Stop spider if it does crawl fast enough

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,6 +15,7 @@ config :crawly,
   item: [:title, :author, :time, :url],
   # Identifier which is used to filter out duplicates
   item_id: :title,
+  max_retries: 2,
   # Stop spider after scraping certain amount of items
   closespider_itemcount: 100,
   # Stop spider if it does crawl fast enough

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -116,11 +116,19 @@ default: 4
 
 The maximum number of concurrent (ie. simultaneous) requests that will be performed by the Crawly workers.
 
+
+### max_retries :: pos_integer()
+
+default: 3
+
+Controlls the amount of retries made by the Crawly in order to fetch a successful
+request (the one with HTTP 200 response).
+    
 ### proxy :: binary()
 
 Requests can be directed through a proxy. It will set the proxy option for the request.
 It's possible to set proxy using the proxy value of Crawly config, for example:
-
+        
 ```
 config :crawly,
     proxy: "<proxy_host>:<proxy_port>",

--- a/lib/crawly/manager.ex
+++ b/lib/crawly/manager.ex
@@ -51,7 +51,7 @@ defmodule Crawly.Manager do
     Process.link(request_storage_pid)
 
     # Store start requests
-    requests = Enum.map(urls, fn url -> %Crawly.Request{url: url} end)
+    requests = Enum.map(urls, fn url -> Crawly.Request.new(url) end)
 
     :ok = Crawly.RequestsStorage.store(spider_name, requests)
 

--- a/lib/crawly/middlewares/domain_filter.ex
+++ b/lib/crawly/middlewares/domain_filter.ex
@@ -20,10 +20,11 @@ defmodule Crawly.Middlewares.DomainFilter do
   def run(request, state, _opts \\ []) do
     base_url = state.spider_name.base_url()
 
-    case String.contains?(request.url, base_url) do
+    url = Crawly.Request.url(request)
+    case String.contains?(url, base_url) do
       false ->
         Logger.debug(
-          "Dropping request: #{inspect(request.url)} (domain filter)"
+          "Dropping request: #{inspect(url)} (domain filter)"
         )
 
         {false, state}

--- a/lib/crawly/middlewares/robotstxt.ex
+++ b/lib/crawly/middlewares/robotstxt.ex
@@ -21,9 +21,10 @@ defmodule Crawly.Middlewares.RobotsTxt do
   require Logger
 
   def run(request, state, _opts \\ []) do
-    case Gollum.crawlable?("Crawly", request.url) do
+    url = Crawly.Request.url(request)
+    case Gollum.crawlable?("Crawly", url) do
       :uncrawlable ->
-        Logger.debug("Dropping request: #{request.url} (robots.txt filter)")
+        Logger.debug("Dropping request: #{url} (robots.txt filter)")
 
         {false, state}
 

--- a/lib/crawly/middlewares/unique_request.ex
+++ b/lib/crawly/middlewares/unique_request.ex
@@ -5,19 +5,15 @@ defmodule Crawly.Middlewares.UniqueRequest do
   """
   require Logger
 
-  # Allow to re-schedule a request if retries are required
-  def run(%Crawly.Request{retries: retries} = request, state) when retries > 0 do
-    {request, state}
-  end
-
   def run(request, state) do
     unique_request_seen_requests =
       Map.get(state, :unique_request_seen_requests, %{})
 
-    case Map.get(unique_request_seen_requests, request.url) do
+    url = Crawly.Request.url(request)
+    case Map.get(unique_request_seen_requests, url) do
       nil ->
         unique_request_seen_requests =
-          Map.put(unique_request_seen_requests, request.url, true)
+          Map.put(unique_request_seen_requests, url, true)
 
         new_state =
           Map.put(
@@ -30,7 +26,7 @@ defmodule Crawly.Middlewares.UniqueRequest do
 
       _ ->
         Logger.debug(
-          "Dropping request: #{request.url}, as it's already processed"
+          "Dropping request: #{url}, as it's already processed"
         )
 
         {false, state}

--- a/lib/crawly/middlewares/unique_request.ex
+++ b/lib/crawly/middlewares/unique_request.ex
@@ -1,8 +1,14 @@
 defmodule Crawly.Middlewares.UniqueRequest do
   @moduledoc """
-  Avoid scheduling requests for the same pages.
+  Avoid scheduling requests for the same pages. However if retry is requested
+  the request is still allowed.
   """
   require Logger
+
+  # Allow to re-schedule a request if retries are required
+  def run(%Crawly.Request{retries: retries} = request, state) when retries > 0 do
+    {request, state}
+  end
 
   def run(request, state) do
     unique_request_seen_requests =
@@ -30,4 +36,5 @@ defmodule Crawly.Middlewares.UniqueRequest do
         {false, state}
     end
   end
+
 end

--- a/lib/crawly/request.ex
+++ b/lib/crawly/request.ex
@@ -4,7 +4,7 @@ defmodule Crawly.Request do
 
   Defines Crawly request structure.
   """
-  defstruct url: nil, headers: [], prev_response: nil, options: []
+  defstruct url: nil, headers: [], prev_response: nil, options: [], retries: 0
 
   @type header() :: {key(), value()}
   @type url() :: binary()
@@ -12,12 +12,15 @@ defmodule Crawly.Request do
   @typep key :: binary()
   @typep value :: binary()
 
+  @type retries :: non_neg_integer()
+
   @type option :: {atom(), binary()}
 
   @type t :: %__MODULE__{
     url: url(),
     headers: [header()],
     prev_response: %{},
+    retries: 0,
     options: [option()]
   }
 end

--- a/lib/crawly/request.ex
+++ b/lib/crawly/request.ex
@@ -2,25 +2,153 @@ defmodule Crawly.Request do
   @moduledoc """
   Request wrapper
 
-  Defines Crawly request structure.
+  Defines Crawly request structure, and API to access Crawly.Request fields
   """
-  defstruct url: nil, headers: [], prev_response: nil, options: [], retries: 0
+
+  ###===========================================================================
+  ### Type definitions
+  ###===========================================================================
+  defstruct url: nil,
+            headers: [],
+            prev_response: nil,
+            options: [],
+            retries: 0,
+            middlewares: []
 
   @type header() :: {key(), value()}
   @type url() :: binary()
 
   @typep key :: binary()
   @typep value :: binary()
-
   @type retries :: non_neg_integer()
-
   @type option :: {atom(), binary()}
+  @opaque t :: %__MODULE__{
+               url: binary(),
+               headers: [header()],
+               prev_response: %{},
+               retries: 0,
+               middlewares: [],
+               options: [option()]
+             }
+  ###===========================================================================
+  ### API functions
+  ###===========================================================================
+  @doc """
+  Create new Crawly.Request from url, headers and options
+  """
+  @spec new(url, headers, options) :: request
+        when url: binary(),
+             headers: [term()],
+             options: [term()],
+             request: Crawly.Request.t()
+  def new(url, headers \\ [], options \\ []) do
+    %Crawly.Request{url: url, headers: headers, options: options}
+  end
 
-  @type t :: %__MODULE__{
-    url: url(),
-    headers: [header()],
-    prev_response: %{},
-    retries: 0,
-    options: [option()]
-  }
+  @doc """
+  Access url field from Crawly.Request
+  """
+  @spec url(request) :: url_field
+        when request: Crawly.Request.t(),
+             url_field: binary()
+  def url(request), do: request.url
+
+  @doc """
+  Set url field in Crawly.Request
+  """
+  @spec url(request, new_url) :: url_field
+        when request: Crawly.Request.t(),
+             new_url: binary(),
+             url_field: binary()
+  def url(request, new_url), do: %Crawly.Request{request | url: new_url}
+
+  @doc """
+  Access headers field from Crawly.Request
+  """
+  @spec headers(request) :: headers_field
+        when request: Crawly.Request.t(),
+             headers_field: [term()]
+  def headers(request), do: request.headers
+
+  @doc """
+  Set headers field in Crawly.Request
+  """
+  @spec headers(request, new_headers) :: headers_field
+        when request: Crawly.Request.t(),
+             new_headers: binary(),
+             headers_field: binary()
+  def headers(request, new_headers),
+      do: %Crawly.Request{request | headers: new_headers}
+
+  @doc """
+  Access prev_response field from Crawly.Request
+  """
+  @spec prev_response(request) :: prev_response_field
+        when request: Crawly.Request.t(),
+             prev_response_field: map()
+  def prev_response(request), do: request.prev_response
+
+  @doc """
+  Set prev_response field in Crawly.Request
+  """
+  @spec prev_response(request, new_prev_response) :: prev_response_field
+        when request: Crawly.Request.t(),
+             new_prev_response: binary(),
+             prev_response_field: binary()
+  def prev_response(request, prev_response),
+      do: %Crawly.Request{request | prev_response: prev_response}
+
+  @doc """
+  Access options field from Crawly.Request
+  """
+  @spec options(request) :: options_field
+        when request: Crawly.Request.t(),
+             options_field: [term()]
+  def options(request), do: request.options
+
+  @doc """
+  Set options field in Crawly.Request
+  """
+  @spec options(request, new_options) :: options_field
+        when request: Crawly.Request.t(),
+             new_options: binary(),
+             options_field: binary()
+  def options(request, new_options),
+      do: %Crawly.Request{request | options: new_options}
+      
+  @doc """
+  Access retries field from Crawly.Request
+  """
+  @spec retries(request) :: retries_field
+        when request: Crawly.Request.t(),
+             retries_field: [term()]
+  def retries(request), do: request.headers
+
+  @doc """
+  Set retries field in Crawly.Request
+  """
+  @spec retries(request, new_retries) :: retries_field
+        when request: Crawly.Request.t(),
+             new_retries: binary(),
+             retries_field: binary()
+  def retries(request, new_retries),
+      do: %Crawly.Request{request | retries: new_retries}
+
+  @doc """
+  Access middlewares field from Crawly.Request
+  """
+  @spec middlewares(request) :: middlewares_field
+        when request: Crawly.Request.t(),
+             middlewares_field: [term()]
+  def middlewares(request), do: request.middlewares
+
+  @doc """
+  Set middlewares field in Crawly.Request
+  """
+  @spec middlewares(request, new_middlewares) :: middlewares_field
+        when request: Crawly.Request.t(),
+             new_middlewares: binary(),
+             middlewares_field: binary()
+  def middlewares(request, new_middlewares),
+      do: %Crawly.Request{request | middlewares: new_middlewares}
 end

--- a/lib/crawly/requests_storage/requests_storage_worker.ex
+++ b/lib/crawly/requests_storage/requests_storage_worker.ex
@@ -33,7 +33,9 @@ defmodule Crawly.RequestsStorage.Worker do
   @spec store(spider_name, request) :: :ok
         when spider_name: atom(),
              request: Crawly.Request.t()
-  def store(pid, request), do: GenServer.call(pid, {:store, request})
+  def store(pid, request) do
+    GenServer.call(pid, {:store, request})
+  end
 
   @doc """
   Pop a request out of requests storage

--- a/lib/crawly/requests_storage/requests_storage_worker.ex
+++ b/lib/crawly/requests_storage/requests_storage_worker.ex
@@ -65,16 +65,7 @@ defmodule Crawly.RequestsStorage.Worker do
 
   # Store the given request
   def handle_call({:store, request}, _from, state) do
-    # Define a list of middlewares which are used by default to process incoming
-    # requests
-    default_middlewares = [
-      Crawly.Middlewares.DomainFilter,
-      Crawly.Middlewares.UniqueRequest,
-      Crawly.Middlewares.RobotsTxt
-    ]
-
-    middlewares =
-      Application.get_env(:crawly, :middlewares, default_middlewares)
+    middlewares = Crawly.Request.middlewares(request)
 
     new_state =
       case Crawly.Utils.pipe(middlewares, request, state) do

--- a/lib/crawly/utils.ex
+++ b/lib/crawly/utils.ex
@@ -104,4 +104,16 @@ defmodule Crawly.Utils do
 
     pipe(pipelines, new_item, new_state)
   end
+
+  @doc """
+  A wrapper over Process.send after
+
+  This wrapper should be used instead of Process.send_after, so it's possible
+  to mock the last one. To avoid race conditions on worker's testing.
+  """
+  @spec send_after(pid(), term(), pos_integer()) :: reference()
+  def send_after(pid, message, timeout) do
+    Process.send_after(pid, message, timeout)
+  end
+
 end

--- a/lib/crawly/utils.ex
+++ b/lib/crawly/utils.ex
@@ -8,7 +8,7 @@ defmodule Crawly.Utils do
   A helper function which returns a Request structure for the given URL
   """
   @spec request_from_url(binary()) :: Crawly.Request.t()
-  def request_from_url(url), do: %Crawly.Request{url: url, headers: []}
+  def request_from_url(url), do: Crawly.Request.new(url)
 
   @doc """
   A helper function which converts a list of URLS into a requests list.

--- a/lib/crawly/worker.ex
+++ b/lib/crawly/worker.ex
@@ -17,14 +17,18 @@ defmodule Crawly.Worker do
   end
 
   def init([spider_name]) do
-    Process.send_after(self(), :work, @default_backoff)
+    Crawly.Utils.send_after(self(), :work, @default_backoff)
 
     {:ok, %Crawly.Worker{spider_name: spider_name, backoff: @default_backoff}}
   end
 
   def handle_info(:work, state) do
-    %{spider_name: spider_name, backoff: backoff} = state
+    new_backoff = do_work(state.spider_name, state.backoff)
+    Crawly.Utils.send_after(self(), :work, new_backoff)
+    {:noreply, %{state | backoff: new_backoff}}
+  end
 
+  defp do_work(spider_name, backoff) do
     # Get a request from requests storage.
     new_backoff =
       case Crawly.RequestsStorage.pop(spider_name) do
@@ -80,11 +84,12 @@ defmodule Crawly.Worker do
     )
 
     case fetcher.fetch(request, options) do
-      {:ok, response} ->
+      {:ok, %HTTPoison.Response{status_code: 200} = response} ->
         {:ok, {response, spider_name}}
 
-      {:error, _reason} = response ->
-        response
+      non_successful_response ->
+        :ok = maybe_retry_request(spider_name, request)
+        {:error, non_successful_response}
     end
   end
 
@@ -157,5 +162,22 @@ defmodule Crawly.Worker do
     )
 
     {:ok, :done}
+  end
+
+  ## Retry a request if max retries allows to do so
+  defp maybe_retry_request(spider, %Crawly.Request{retries: retries} = request) do
+    max_retires = Application.get_env(:crawly, :max_retries, 3)
+
+    case retries <= max_retires do
+      true ->
+        Logger.info("Request to #{request.url}, is scheduled for retry")
+        :ok = Crawly.RequestsStorage.store(
+          spider,
+          %Crawly.Request{request | retries: retries + 1}
+        )
+      false ->
+        Logger.info("Dropping request to #{request.url}, (max retries)")
+        :ok
+    end
   end
 end

--- a/test/request_storage_test.exs
+++ b/test/request_storage_test.exs
@@ -24,11 +24,7 @@ defmodule RequestStorageTest do
   end
 
   test "Request storage can store requests", context do
-    request = %Crawly.Request{
-      url: "http://example.com",
-      headers: [],
-      options: []
-    }
+    request = Crawly.Request.new("http://example.com")
 
     :ok = Crawly.RequestsStorage.store(context.crawler, request)
     {:stored_requests, num} = Crawly.RequestsStorage.stats(context.crawler)
@@ -36,12 +32,7 @@ defmodule RequestStorageTest do
   end
 
   test "Request storage returns request for given spider", context do
-    request = %Crawly.Request{
-      url: "http://example.com",
-      headers: [],
-      options: []
-    }
-
+    request = Crawly.Request.new("http://example.com")
     :ok = Crawly.RequestsStorage.store(context.crawler, request)
 
     returned_request = Crawly.RequestsStorage.pop(context.crawler)
@@ -64,12 +55,7 @@ defmodule RequestStorageTest do
   end
 
   test "Duplicated requests are filtered out", context do
-    request = %Crawly.Request{
-      url: "http://example.com",
-      headers: [],
-      options: []
-    }
-
+    request = Crawly.Request.new("http://example.com")
     :ok = Crawly.RequestsStorage.store(context.crawler, request)
     :ok = Crawly.RequestsStorage.store(context.crawler, request)
 
@@ -91,11 +77,7 @@ defmodule RequestStorageTest do
   end
 
   test "Outbound requests are filtered out", context do
-    request = %Crawly.Request{
-      url: "http://otherdomain.com",
-      headers: [],
-      options: []
-    }
+    request = Crawly.Request.new("http://otherdomain.com")
 
     :ok = Crawly.RequestsStorage.store(context.crawler, request)
     {:stored_requests, num} = Crawly.RequestsStorage.stats(context.crawler)
@@ -103,11 +85,7 @@ defmodule RequestStorageTest do
   end
 
   test "Robots.txt is respected", context do
-    request = %Crawly.Request{
-      url: "http://example.com/filter",
-      headers: [],
-      options: []
-    }
+    request = Crawly.Request.new("http://example.com/filter")
 
     :meck.expect(Gollum, :crawlable?, fn _, "http://example.com/filter" ->
       :uncrawlable

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -9,19 +9,21 @@ defmodule UtilsTest do
 
   test "Request from url" do
     requests = Crawly.Utils.request_from_url("https://test.com")
-    assert requests == %Crawly.Request{url: "https://test.com", headers: []}
+    assert requests == Crawly.Request.new("https://test.com")
   end
 
   test "Requests from urls" do
     requests =
-      Crawly.Utils.requests_from_urls([
-        "https://test.com",
-        "https://example.com"
-      ])
+      Crawly.Utils.requests_from_urls(
+        [
+          "https://test.com",
+          "https://example.com"
+        ]
+      )
 
     assert requests == [
-             %Crawly.Request{url: "https://test.com", headers: []},
-             %Crawly.Request{url: "https://example.com", headers: []}
+             Crawly.Request.new("https://test.com"),
+             Crawly.Request.new("https://example.com")
            ]
   end
 

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -101,6 +101,7 @@ defmodule WorkerTest do
       send(context.crawler, :work)
 
       response = receive_mocked_response()
+
       assert response != false
       assert response.retries == 1
 

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -46,13 +46,9 @@ defmodule WorkerTest do
 
   describe "Check different incorrect status codes from HTTP client" do
     setup do
-      :meck.expect(Crawly.RequestsStorage, :pop, fn _ ->
-        Crawly.Utils.request_from_url("https://example.com")
-      end)
+      :meck.expect(Crawly.Utils, :send_after, fn _, _, _ -> :ignore end)
 
-      spider_name = Worker.CrashingTestSpider
-
-      :meck.new(spider_name, [:non_strict])
+      spider_name = Elixir.Worker.CrashingTestSpider
 
       {:ok, storage_pid} = Crawly.DataStorage.start_worker(spider_name)
 
@@ -64,36 +60,27 @@ defmodule WorkerTest do
           spider_name,
           {Crawly.Worker, [spider_name]}
         )
+      {:ok, requests_storage_pid} = Crawly.RequestsStorage.start_worker(
+        spider_name
+      )
+      :ok = Crawly.RequestsStorage.store(
+        spider_name,
+        Crawly.Utils.request_from_url("https://www.example.com")
+      )
 
       on_exit(fn ->
-        :meck.unload(Crawly.RequestsStorage)
-        :meck.unload(HTTPoison)
+        :meck.unload()
 
         :ok = TestUtils.stop_process(workers_sup)
         :ok = TestUtils.stop_process(storage_pid)
+        :ok = TestUtils.stop_process(requests_storage_pid)
       end)
 
-      {:ok, %{crawler: pid, name: spider_name}}
-    end
-
-    test "Pages with http 500 are handled correctly", context do
-      :meck.expect(HTTPoison, :get, fn _, _, _ ->
-        {:ok,
-         %HTTPoison.Response{
-           status_code: 500,
-           body: "",
-           headers: [],
-           request: %{}
-         }}
-      end)
-
-      send(context.crawler, :work)
-      Process.sleep(1_000)
-
-      assert Process.alive?(context.crawler)
+      {:ok, %{crawler: pid, name: spider_name, requests_storage: requests_storage_pid}}
     end
 
     test "Pages with http 404 are handled correctly", context do
+      test_pid = self()
       :meck.expect(HTTPoison, :get, fn _, _, _ ->
         {:ok,
          %HTTPoison.Response{
@@ -104,18 +91,39 @@ defmodule WorkerTest do
          }}
       end)
 
-      # send(context.crawler, :work)
-      Process.sleep(1_000)
+      # Mock the request storage, so we can see how request looks like
+      :meck.expect(Crawly.RequestsStorage, :store, fn _spider_name, request ->
+        send(test_pid, {:request, request})
+        :ok
+      end)
+
+      # Start actual work
+      send(context.crawler, :work)
+
+      response = receive_mocked_response()
+      assert response != false
+      assert response.retries == 1
+
       assert Process.alive?(context.crawler)
     end
 
     test "Pages with http timeout are handled correctly", context do
+      test_pid = self()
       :meck.expect(HTTPoison, :get, fn _, _, _ ->
         {:error, %HTTPoison.Error{id: nil, reason: :timeout}}
       end)
 
+      # Mock the request storage, so we can see how request looks like
+      :meck.expect(Crawly.RequestsStorage, :store, fn _spider_name, request ->
+        send(test_pid, {:request, request})
+        :ok
+      end)
+
       send(context.crawler, :work)
-      Process.sleep(1_000)
+
+      response = receive_mocked_response()
+      assert response != false
+      assert response.retries == 1
       assert Process.alive?(context.crawler)
     end
 
@@ -130,15 +138,70 @@ defmodule WorkerTest do
          }}
       end)
 
-      Process.sleep(1_000)
+      send(context.crawler, :work)
       assert Process.alive?(context.crawler)
+    end
+
+    test "Requests are dropped after 3 attempts", context do
+      :meck.expect(HTTPoison, :get, fn _, _, _ ->
+        {:ok,
+          %HTTPoison.Response{
+            status_code: 500,
+            body: "Some page",
+            headers: [],
+            request: %{}
+          }}
+      end)
+
+      # Check if request is really dropped
+      send(context.crawler, :work)
+      send(context.crawler, :work)
+      send(context.crawler, :work)
+      send(context.crawler, :work)
+
+      # For now I don't see a good way of understanding when the worker
+      # have finished it's work. So have to do this ugly sleep
+      Process.sleep(1000)
+
+      {:stored_requests, num} =
+        Crawly.DataStorage.Worker.stats(context.requests_storage)
+      assert num == 0
+
+
+      assert Process.alive?(context.crawler)
+    end
+  end
+
+  defp receive_mocked_response() do
+    # Check to see if request is added back to the request storage,
+    # and if the number of retries was incremented
+    receive do
+      {:request, req} ->
+        req
+    after 1000 ->
+      false
     end
   end
 
 end
 
 defmodule Worker.CrashingTestSpider do
+  @behaviour Crawly.Spider
+
+  @impl Crawly.Spider
+  def base_url() do
+    "https://www.example.com"
+  end
+
+  @impl Crawly.Spider
+  def init() do
+    [
+      start_urls: ["https://www.example.com"]
+    ]
+  end
+
+  @impl Crawly.Spider
   def parse_item(_response) do
-    {:error, :error}
+    {[], []}
   end
 end


### PR DESCRIPTION
Try to fetch unsuccessful requests more then once. The amount
of attempts is controlled by the max retries setting.