### PR TITLE
Fix follow redirect option passed to HTTPoison and configuration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ historical archival.
    config :crawly,
      closespider_timeout: 10,
      concurrent_requests_per_domain: 8,
-     follow_redirects: true,
+     follow_redirect: true,
      closespider_itemcount: 1000,
      middlewares: [
        Crawly.Middlewares.DomainFilter,

--- a/config/config.exs
+++ b/config/config.exs
@@ -55,7 +55,7 @@ config :crawly,
   # Stop spider if it does crawl fast enough
   closespider_timeout: 20,
   concurrent_requests_per_domain: 5,
-  follow_redirects: true,
+  follow_redirect: true,
   # Request middlewares
   middlewares: [
     Crawly.Middlewares.DomainFilter,

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,7 +13,7 @@ config :crawly,
          # Stop spider if it does crawl fast enough
        closespider_timeout: 20,
        concurrent_requests_per_domain: 5,
-       follow_redirects: true,
+       follow_redirect: true,
          # Request middlewares
        middlewares: [
          Crawly.Middlewares.DomainFilter,

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -104,7 +104,7 @@ default: nil
 
 Defines a minimal amount of items which needs to be scraped by the spider within the given timeframe (30s). If the limit is not reached by the spider - it will be stopped.
 
-### follow_redirects :: boolean()
+### follow_redirect :: boolean()
 
 default: false
 

--- a/documentation/quickstart.md
+++ b/documentation/quickstart.md
@@ -56,7 +56,7 @@ Goals:
    config :crawly,
      closespider_timeout: 10,
      concurrent_requests_per_domain: 8,
-     follow_redirects: true,
+     follow_redirect: true,
      closespider_itemcount: 1000,
      middlewares: [
        Crawly.Middlewares.DomainFilter,

--- a/lib/crawly.ex
+++ b/lib/crawly.ex
@@ -12,7 +12,7 @@ defmodule Crawly do
              headers: [],
              options: []
   def fetch(url, headers \\ [], options \\ []) do
-    options = [Application.get_env(:crawly, :follow_redirect, false)] ++ options
+    options = [follow_redirect: Application.get_env(:crawly, :follow_redirect, false)] ++ options
 
     options =
       case Application.get_env(:crawly, :proxy, false) do

--- a/lib/crawly/worker.ex
+++ b/lib/crawly/worker.ex
@@ -136,7 +136,7 @@ defmodule Crawly.Worker do
     items = Map.get(parsed_item, :items, [])
 
     # Reading HTTP client options
-    options = [Application.get_env(:crawly, :follow_redirect, false)]
+    options = [follow_redirect: Application.get_env(:crawly, :follow_redirect, false)]
 
     options =
       case Application.get_env(:crawly, :proxy, false) do


### PR DESCRIPTION
The follow redirect option wasn't being passed correctly to HTTPoison, and the documentation for the name of the option was also different than what the code was looking for.