### PR TITLE
Some slight changes to decrease errors and shutting down early

### DIFF
--- a/lib/crawly/manager_sup.ex
+++ b/lib/crawly/manager_sup.ex
@@ -17,6 +17,6 @@ defmodule Crawly.ManagerSup do
       {Crawly.Manager, spider_name}
     ]
 
-    Supervisor.init(children, strategy: :one_for_one)
+    Supervisor.init(children, strategy: :one_for_all)
   end
 end

--- a/lib/crawly/worker.ex
+++ b/lib/crawly/worker.ex
@@ -64,6 +64,12 @@ defmodule Crawly.Worker do
     {:noreply, %{state | backoff: new_backoff}}
   end
 
+  # Catch ssl closed error coming from HTTPoison
+  def handle_info({:ssl_closed, _}, %{spider_name: _, backoff: backoff} = state) do
+    Crawly.Utils.send_after(self(), :work, backoff)
+    {:noreply, state}
+  end
+
   @spec get_response({request, spider_name}) :: result
         when request: Crawly.Request.t(),
              spider_name: atom(),


### PR DESCRIPTION
I ran into a lot of the following errors, which seem to come from a bug in HTTPoison or hackney. 

```
[error] GenServer #PID<0.1656.0> terminating
** (FunctionClauseError) no function clause matching in Crawly.Worker.handle_info/2
    (crawly) lib/crawly/worker.ex:25: Crawly.Worker.handle_info({:ssl_closed, {:sslsocket, {:gen_tcp, #Port<0.255>, :tls_connection, :undefined}, [#PID<0.1556.0>, #PID<0.1555.0>]}}, %Crawly.Worker{backoff: 300, spider_name: Job.Spider})
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:ssl_closed, {:sslsocket, {:gen_tcp, #Port<0.255>, :tls_connection, :undefined}, [#PID<0.1556.0>, #PID<0.1555.0>]}}
```

This eventually led to all my workers crashing and the worker DynamicSupervisor crashing. This change catches most of the errors, and also restarts the manager process to repopulate the workers if the DynamicSupervisor crashes. 
