### PR TITLE
Add the option to change the port on application.ex

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ historical archival.
        {Crawly.Pipelines.DuplicatesFilter, item_id: :title},
        Crawly.Pipelines.JSONEncoder,
        {Crawly.Pipelines.WriteToFile, extension: "jl", folder: "/tmp"} # NEW IN 0.7.0
-      ]
+      ],
+      port: 4001
    ```
 5. Start the Crawl:
    - `$ iex -S mix`

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -153,7 +153,12 @@ Example:
 
 ### fetcher :: atom()
 
-default: Crawly.Fetchers.HTTPoisonFetcher 
+default: Crawly.Fetchers.HTTPoisonFetcher
 
-Allows to specify a custom HTTP client which will be performing request to the crawl
-target.
+Allows to specify a custom HTTP client which will be performing request to the crawler target.
+
+### port :: pos_integer()
+
+default: 4001
+
+Allows to specify a custom port to start the application. That is important when running more than one application in a single machine, in which case shall not use the same port as the others.

--- a/lib/crawly/application.ex
+++ b/lib/crawly/application.ex
@@ -21,7 +21,9 @@ defmodule Crawly.Application do
        strategy: :one_for_one,
        name: Crawly.DataStorage.WorkersSup},
       {Plug.Cowboy,
-       scheme: :http, plug: Crawly.API.Router, options: [port: 4001]}
+       scheme: :http, 
+       plug: Crawly.API.Router, 
+       options: [port: Application.get_env(:crawly, :port, 4001)]}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html


### PR DESCRIPTION
Hi.

I was getting this error when trying to start two terminals at the same time:
```
** (Mix) Could not start application crawly: Crawly.Application.start(:normal, []) returned an error: shutdown: failed to start child: {:ranch_listener_sup, Crawly.API.Router.HTTP}
    ** (EXIT) shutdown: failed to start child: :ranch_acceptors_sup
        ** (EXIT) {:listen_error, Crawly.API.Router.HTTP, :eaddrinuse}
~
```

Because of that i searched for a option to change the port that cowboy uses, but i did't found one, so I have came up with this.
If you agree with the proposed changes, i will update all the documentation markdowns :+1: 

Great lib, i really helping me out: