### PR TITLE
Handle CSVEncoder misconfiguration

### DIFF
--- a/lib/crawly/pipelines/csv_encoder.ex
+++ b/lib/crawly/pipelines/csv_encoder.ex
@@ -18,10 +18,10 @@ defmodule Crawly.Pipelines.CSVEncoder do
           {false, state :: map} | {csv_line :: String.t(), state :: map}
   def run(item, state, opts \\ []) do
     opts = Enum.into(opts, %{fields: nil})
-    fields = Map.get(opts, :fields, [])
+    fields = Map.get(opts, :fields)
 
     case fields do
-      :undefined ->
+      nil ->
         # only for when both tuple and global config is not provided
 
         Logger.error(

--- a/lib/crawly/pipelines/csv_encoder.ex
+++ b/lib/crawly/pipelines/csv_encoder.ex
@@ -17,6 +17,7 @@ defmodule Crawly.Pipelines.CSVEncoder do
   @spec run(map, map, fields: list(atom)) ::
           {false, state :: map} | {csv_line :: String.t(), state :: map}
   def run(item, state, opts \\ []) do
+    opts = Enum.into(opts, %{fields: nil})
     case opts[:fields] do
       fields when fields in [nil, []] ->
         Logger.error(

--- a/lib/crawly/pipelines/csv_encoder.ex
+++ b/lib/crawly/pipelines/csv_encoder.ex
@@ -17,13 +17,8 @@ defmodule Crawly.Pipelines.CSVEncoder do
   @spec run(map, map, fields: list(atom)) ::
           {false, state :: map} | {csv_line :: String.t(), state :: map}
   def run(item, state, opts \\ []) do
-    opts = Enum.into(opts, %{fields: nil})
-    fields = Map.get(opts, :fields)
-
-    case fields do
-      nil ->
-        # only for when both tuple and global config is not provided
-
+    case opts[:fields] do
+      fields when fields in [nil, []] ->
         Logger.error(
           "Dropping item: #{inspect(item)}. Reason: No fields declared for CSVEncoder"
         )

--- a/test/pipelines/csv_encoder_test.exs
+++ b/test/pipelines/csv_encoder_test.exs
@@ -1,24 +1,30 @@
 defmodule Pipelines.CSVEncoderTest do
   use ExUnit.Case, async: false
 
-  @valid %{first: "some", second: "data"}
+  @item %{first: "some", second: "data"}
+  @state %{}
+
   test "Converts a single-level map to a csv string with fields config" do
     pipelines = [{Crawly.Pipelines.CSVEncoder, fields: [:first, :second]}]
-    item = @valid
-    state = %{}
 
-    {item, _state} = Crawly.Utils.pipe(pipelines, item, state)
+    {item, _state} = Crawly.Utils.pipe(pipelines, @item, @state)
 
     assert is_binary(item)
     assert item == ~S("some","data")
   end
 
+  test "Drops an item if fields are empty" do
+    pipelines = [{Crawly.Pipelines.CSVEncoder, fields: []}]
+
+    {item, _state} = Crawly.Utils.pipe(pipelines, @item, @state)
+
+    assert item == false
+  end
+
   test "Drops an item if fields are not declared" do
     pipelines = [{Crawly.Pipelines.CSVEncoder}]
-    item = @valid
-    state = %{}
 
-    {item, _state} = Crawly.Utils.pipe(pipelines, item, state)
+    {item, _state} = Crawly.Utils.pipe(pipelines, @item, @state)
 
     assert item == false
   end

--- a/test/pipelines/csv_encoder_test.exs
+++ b/test/pipelines/csv_encoder_test.exs
@@ -2,7 +2,7 @@ defmodule Pipelines.CSVEncoderTest do
   use ExUnit.Case, async: false
 
   @valid %{first: "some", second: "data"}
-  test "Converts a single-level map to a csv string with global config" do
+  test "Converts a single-level map to a csv string with fields config" do
     pipelines = [{Crawly.Pipelines.CSVEncoder, fields: [:first, :second]}]
     item = @valid
     state = %{}
@@ -13,14 +13,13 @@ defmodule Pipelines.CSVEncoderTest do
     assert item == ~S("some","data")
   end
 
-  test "Converts a single-level map to a csv string with tuple config" do
-    pipelines = [{Crawly.Pipelines.CSVEncoder, fields: [:first, :second]}]
+  test "Drops an item if fields are not declared" do
+    pipelines = [{Crawly.Pipelines.CSVEncoder}]
     item = @valid
     state = %{}
 
     {item, _state} = Crawly.Utils.pipe(pipelines, item, state)
 
-    assert is_binary(item)
-    assert item == ~S("some","data")
+    assert item == false
   end
 end


### PR DESCRIPTION
I think I've found a bug in `CSVEncoder` - when I don't supply any fields to it, it throws errors like these:

```
15:29:42.692 [error] Pipeline crash: Elixir.Crawly.Pipelines.CSVEncoder, error: :error, reason: %Protocol.UndefinedError{description: "", protocol: Enumerable, value: nil}, args: nil
 
15:29:42.700 [error] Could not write item: :error, reason: %Protocol.UndefinedError{description: "", protocol: String.Chars, value: %{author: "", text: "", title: "", url: "https://www.erlang-solutions.com/blog.html"}}, stacktrace: [{String.Chars, :impl_for!, 1, [file: 'lib/string/chars.ex', line: 3]}, {String.Chars, :to_string, 1, [file: 'lib/string/chars.ex', line: 22]}, {IO, :write, 2, [file: 'lib/io.ex', line: 654]}, {Crawly.Pipelines.WriteToFile, :write, 2, [file: 'lib/crawly/pipelines/write_to_file.ex', line: 97]}, {Crawly.Pipelines.WriteToFile, :run, 3, [file: 'lib/crawly/pipelines/write_to_file.ex', line: 69]}, {Crawly.Utils, :pipe, 3, [file: 'lib/crawly/utils.ex', line: 91]}, {Crawly.DataStorage.Worker, :handle_cast, 2, [file: 'lib/crawly/data_storage/data_storage_worker.ex', line: 39]}, {:gen_server, :try_dispatch, 4, [file: 'gen_server.erl', line: 637]}]
```

It's because when fields are missing, the `fields` variable holds `nil` and is not caught by [this case branch](https://github.com/oltarasenko/crawly/compare/master...michaltrzcinka:handle_csv_encoder_misconfiguration?expand=1#diff-ec15ab1c2f425730a9512a2f280da22cL24).