### PR TITLE
Change Crawly.ParsedItem.t() typespec

### DIFF
--- a/lib/crawly/parsed_item.ex
+++ b/lib/crawly/parsed_item.ex
@@ -5,7 +5,7 @@ defmodule Crawly.ParsedItem do
 
   defstruct items: [], requests: []
 
-  @type item() :: %{}
+  @type item() :: map()
   @type t :: %__MODULE__{
     items: [item()],
     requests: [Crawly.Request.t()]


### PR DESCRIPTION
This PR introduces a small fix for the `Crawly.ParsedItem.t()` type. The bug was that the current type only matches with the empty map `%{}` instead of an arbitrary map.