### PR TITLE
added Crawly.Engine.list_known_spiders/0

### DIFF
--- a/lib/crawly/engine.ex
+++ b/lib/crawly/engine.ex
@@ -60,21 +60,7 @@ defmodule Crawly.Engine do
   end
 
   def handle_call(:list_spiders, _from, state) do
-    list =
-      Crawly.Utils.list_spiders()
-      |> Enum.map(fn name ->
-        %{
-          name: name,
-          state:
-            case Map.has_key?(state.started_spiders, name) do
-              true -> :started
-              false -> :stopped
-            end,
-          pid: Map.get(state.started_spiders, name)
-        }
-      end)
-
-    {:reply, list, state}
+    {:reply, list_all_spider_status(state.started_spiders), state}
   end
 
   def handle_call({:start_spider, spider_name}, _form, state) do
@@ -112,5 +98,20 @@ defmodule Crawly.Engine do
       end
 
     {:reply, msg, %Crawly.Engine{state | started_spiders: new_started_spiders}}
+  end
+
+  defp list_all_spider_status(started_spiders) do
+    Crawly.Utils.list_spiders()
+    |> Enum.map(fn name ->
+      %{
+        name: name,
+        state:
+          case Map.has_key?(started_spiders, name) do
+            true -> :started
+            false -> :stopped
+          end,
+        pid: Map.get(started_spiders, name)
+      }
+    end)
   end
 end

--- a/test/engine_test.exs
+++ b/test/engine_test.exs
@@ -1,0 +1,21 @@
+defmodule EngineTest do
+  use ExUnit.Case
+
+  test "list_spiders/0 lists all spiders and their current status in the engine" do
+    assert spiders = Crawly.Engine.list_spiders()
+    assert [_ | _] = spiders
+    assert status = Enum.find(spiders, fn s -> s.name == TestSpider end)
+    assert status.state == :stopped
+    assert status.pid == nil
+
+    # test a started spider
+    Crawly.Engine.start_spider(TestSpider)
+
+    assert started_status =
+             Crawly.Engine.list_spiders()
+             |> Enum.find(fn s -> s.name == TestSpider end)
+
+    assert started_status.state == :started
+    assert started_status.pid
+  end
+end

--- a/test/engine_test.exs
+++ b/test/engine_test.exs
@@ -1,21 +1,27 @@
 defmodule EngineTest do
   use ExUnit.Case
 
-  test "list_spiders/0 lists all spiders and their current status in the engine" do
-    assert spiders = Crawly.Engine.list_spiders()
+  test "list_known_spiders/0 lists all spiders and their current status in the engine" do
+    Crawly.Engine.init([])
+    Crawly.Engine.refresh_spider_list()
+    spiders = Crawly.Engine.list_known_spiders()
     assert [_ | _] = spiders
     assert status = Enum.find(spiders, fn s -> s.name == TestSpider end)
-    assert status.state == :stopped
-    assert status.pid == nil
+    assert status.status == :stopped
 
     # test a started spider
     Crawly.Engine.start_spider(TestSpider)
 
     assert started_status =
-             Crawly.Engine.list_spiders()
+             Crawly.Engine.list_known_spiders()
              |> Enum.find(fn s -> s.name == TestSpider end)
 
-    assert started_status.state == :started
+    assert :started = started_status.status
     assert started_status.pid
+
+    # stop spider
+    Crawly.Engine.stop_spider(TestSpider)
+    spiders = Crawly.Engine.list_known_spiders()
+    assert Enum.all?(spiders, fn s -> s.status == :stopped end)
   end
 end


### PR DESCRIPTION
Adds a `list_known_spiders/0`, `refresh_spider_list/0` functions to `Crawly.Engine`. 

Expected behaviour: 
- lists all started/stopped spiders and their pid if available.

Behaviour intersects with `Crawly.Engine.running_spiders/0`, it may be a good idea to remove `running_spiders/0` and add in a filter option for `list_spiders/0`