### PR TITLE
Fix quickstart link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ See more at [Experimental UI](https://hexdocs.pm/crawly/experimental_ui.html#con
 ## Documentation
 
 - [API Reference](https://hexdocs.pm/crawly/api-reference.html#content)
-- [Quickstart](https://hexdocs.pm/crawly/quickstart.html)
+- [Quickstart](https://hexdocs.pm/crawly/readme.html#quickstart)
 - [Tutorial](https://hexdocs.pm/crawly/tutorial.html)
 
 ## Roadmap


### PR DESCRIPTION
When trying to access the Quickstart link in the readme `https://hexdocs.pm/crawly/quickstart.html` I got a 404

![Screenshot 2020-06-19 at 17 13 15](https://user-images.githubusercontent.com/52708/85148282-3edcb180-b250-11ea-9f6d-aee225cc4464.png)

So I changed it to https://hexdocs.pm/crawly/readme.html#quickstart

![Screenshot 2020-06-19 at 17 14 31](https://user-images.githubusercontent.com/52708/85148420-67fd4200-b250-11ea-928b-7a775f0e06d4.png)
