### PR TITLE
Format sample config.exs on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ historical archival.
        {Crawly.Pipelines.DuplicatesFilter, item_id: :title},
        Crawly.Pipelines.JSONEncoder,
        {Crawly.Pipelines.WriteToFile, extension: "jl", folder: "/tmp"}
-      ]
+     ]
    ```
 5. Start the Crawl:
    - `$ iex -S mix`


### PR DESCRIPTION
There is an extra space.

I listened to your ElixirConf EU session.
I enjoyed it.
I tried the Quickstart.
Good! It works easy for me.

I guess that sample config.exs has an extra space on README.