### PR TITLE
[fix] crawly worker backoff time

### DIFF
--- a/lib/crawly/worker.ex
+++ b/lib/crawly/worker.ex
@@ -8,7 +8,7 @@ defmodule Crawly.Worker do
   require Logger
 
   # define the default worker fetch interval.
-  @default_backoff 25_000
+  @default_backoff 10_000
 
   defstruct backoff: @default_backoff, spider_name: nil
 

--- a/test/worker_test.exs
+++ b/test/worker_test.exs
@@ -32,7 +32,7 @@ defmodule WorkerTest do
     test "Backoff increased when there is no work", context do
       send(context.crawler, :work)
       state = :sys.get_state(context.crawler)
-      assert state.backoff > 25_000
+      assert state.backoff > 10_000
     end
 
     test "Backoff interval restores if requests are in the system", context do
@@ -46,7 +46,7 @@ defmodule WorkerTest do
 
       send(context.crawler, :work)
       state = :sys.get_state(context.crawler)
-      assert state.backoff == 25_000
+      assert state.backoff == 10_000
     end
   end
 


### PR DESCRIPTION
Fixing the backoff default time for Crawly worker. The backoff as 25s was causing big delays. The workers are having an extra backoff -> 25s * 2.




