### PR TITLE
[Fix] Do not close spider with :itemcount_timeout when closespider_timeout is set to :disabled

### DIFF
--- a/lib/crawly/manager.ex
+++ b/lib/crawly/manager.ex
@@ -109,11 +109,11 @@ defmodule Crawly.Manager do
       |> Utils.get_settings(state.name)
       |> maybe_convert_to_integer()
 
-      maybe_stop_spider_by_timeout(
-        state.name,
+    maybe_stop_spider_by_timeout(
+      state.name,
       delta,
-        closespider_timeout_limit
-      )
+      closespider_timeout_limit
+    )
 
     tref =
       Process.send_after(
@@ -137,7 +137,7 @@ defmodule Crawly.Manager do
   defp maybe_stop_spider_by_itemcount_limit(_, _, _), do: :ok
 
   defp maybe_stop_spider_by_timeout(spider_name, current, limit)
-       when current < limit do
+       when current < limit and is_integer(limit) do
     Logger.info("Stopping #{inspect(spider_name)}, itemcount timeout achieved")
 
     Crawly.Engine.stop_spider(spider_name, :itemcount_timeout)

--- a/test/manager_test.exs
+++ b/test/manager_test.exs
@@ -90,13 +90,13 @@ defmodule ManagerTest do
     assert %{} == Crawly.Engine.running_spiders()
   end
 
-  @tag timeout: 61_000
   test "spider does not close after 1 minute when closespider timeout is disabled" do
     Application.put_env(:crawly, :closespider_timeout, :disabled)
+    Application.put_env(:crawly, :manager_operations_timeout, 1_000)
 
     :ok = Crawly.Engine.start_spider(Manager.TestSpider)
 
-    Process.sleep(60_000)
+    Process.sleep(1_001)
 
     refute %{} == Crawly.Engine.running_spiders()
 


### PR DESCRIPTION
I notice that the spider is closed with reason "..itemcount timeout achieved" after 1 minute even though I do not config `closespider_timeout` (disabled by default). Oleg points out that it could be because in `Crawly.Manager.maybe_stop_spider_by_timeout/3` when limit is an atom, it is always evaluated to `true` and stop. I added a condition that the `limit` should be an integer, else it should go to the :ok clause.
