### PR TITLE
Don't print debug messages when listing spiders

### DIFF
--- a/lib/crawly/utils.ex
+++ b/lib/crawly/utils.ex
@@ -166,8 +166,8 @@ defmodule Crawly.Utils do
               acc
           end
         rescue
-          error ->
-            Logger.debug("Could not get behaviour information for: #{inspect(error)}")
+          _error ->
+            # Just ignore the case, as probably the given module is not a Spider
             acc
         end
       end


### PR DESCRIPTION
Listing spiders is a bit complex operation which checks all the modules
in the system. We were Logging all attempts to get behavior info
from modules, and it was very noisy.