### PR TITLE
Extend domain filter with "share link" urls

### DIFF
--- a/lib/crawly/middlewares/domain_filter.ex
+++ b/lib/crawly/middlewares/domain_filter.ex
@@ -20,8 +20,9 @@ defmodule Crawly.Middlewares.DomainFilter do
   def run(request, state, _opts \\ []) do
     base_url = state.spider_name.base_url()
     parsed_url = URI.parse(request.url)
+    host = parsed_url.host
 
-    case String.contains?(base_url, parsed_url.host) do
+    case host != nil and String.contains?(base_url, host) do
       false ->
         Logger.debug(
           "Dropping request: #{inspect(request.url)} (domain filter)"

--- a/lib/crawly/middlewares/domain_filter.ex
+++ b/lib/crawly/middlewares/domain_filter.ex
@@ -19,8 +19,9 @@ defmodule Crawly.Middlewares.DomainFilter do
 
   def run(request, state, _opts \\ []) do
     base_url = state.spider_name.base_url()
+    parsed_url = URI.parse(request.url)
 
-    case String.contains?(request.url, base_url) do
+    case String.contains?(base_url, parsed_url.host) do
       false ->
         Logger.debug(
           "Dropping request: #{inspect(request.url)} (domain filter)"

--- a/test/middlewares/domain_filter_test.exs
+++ b/test/middlewares/domain_filter_test.exs
@@ -46,4 +46,16 @@ defmodule Middlewares.DomainFilterTest do
 
     assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
   end
+
+  test "Non absolute url should not crash the middleware" do
+    middlewares = [Crawly.Middlewares.DomainFilter]
+
+    req = %Crawly.Request{
+      url: "/blog"
+    }
+
+    state = %{spider_name: :test_spider}
+
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
 end

--- a/test/middlewares/domain_filter_test.exs
+++ b/test/middlewares/domain_filter_test.exs
@@ -1,19 +1,47 @@
 defmodule Middlewares.DomainFilterTest do
   use ExUnit.Case, async: false
 
-  @valid %Crawly.Request{url: "https://www.some_url.com"}
   setup do
     :meck.new(:test_spider, [:non_strict])
-    :meck.expect(:test_spider, :base_url, fn -> "example.com" end)
+
+    :meck.expect(:test_spider, :base_url, fn ->
+      "https://www.erlang-solutions.com"
+    end)
 
     on_exit(fn ->
-      Application.put_env(:crawly, :item_id, :title)
+      :meck.unload()
     end)
   end
 
   test "Filters out requests that do not contain a spider's base_url" do
     middlewares = [Crawly.Middlewares.DomainFilter]
-    req = @valid
+    req = %Crawly.Request{url: "https://www.some_url.com"}
+    state = %{spider_name: :test_spider}
+
+    assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)
+  end
+
+  test "Does not filter out requests with correct urls" do
+    middlewares = [Crawly.Middlewares.DomainFilter]
+
+    req = %Crawly.Request{
+      url: "https://www.erlang-solutions.com/blog/web-scraping-with-elixir.html"
+    }
+
+    state = %{spider_name: :test_spider}
+
+    {maybe_request, _state} = Crawly.Utils.pipe(middlewares, req, state)
+    assert %Crawly.Request{} = maybe_request
+  end
+
+  test "Filters out 'share' urls" do
+    middlewares = [Crawly.Middlewares.DomainFilter]
+
+    req = %Crawly.Request{
+      url:
+        "https://twitter.com?share=https://www.erlang-solutions.com/blog/web-scraping-with-elixir.html"
+    }
+
     state = %{spider_name: :test_spider}
 
     assert {false, _state} = Crawly.Utils.pipe(middlewares, req, state)


### PR DESCRIPTION
Looks like urls like https://twitter.com?link=our_link was not
filtered out before. I have added filter for this and tests