### PR TITLE
Simplify manager init function

### DIFF
--- a/lib/crawly/requests_storage/requests_storage.ex
+++ b/lib/crawly/requests_storage/requests_storage.ex
@@ -49,8 +49,13 @@ defmodule Crawly.RequestsStorage do
   @spec store(spider_name, request) :: :ok
         when spider_name: atom(),
              request: Crawly.Request.t()
-  def store(spider_name, request) do
+  def store(spider_name, %Crawly.Request{} = request) do
     store(spider_name, [request])
+  end
+
+  def store(_spider_name, request) do
+    Logger.error("#{inspect(request)} does not seem to be a request. Ignoring.")
+    {:error, :not_request}
   end
 
   @doc """

--- a/lib/crawly/requests_storage/requests_storage_worker.ex
+++ b/lib/crawly/requests_storage/requests_storage_worker.ex
@@ -105,8 +105,8 @@ defmodule Crawly.RequestsStorage.Worker do
       GenServer.call(pid, command)
     catch
       error, reason ->
-        Logger.error("Could not fetch a request: #{inspect(reason)}")
-        Logger.error(Exception.format(:error, error, __STACKTRACE__))
+        Logger.debug("Could not fetch a request: #{inspect(reason)}")
+        Logger.debug(Exception.format(:error, error, __STACKTRACE__))
     end
   end
 end

--- a/test/manager_test.exs
+++ b/test/manager_test.exs
@@ -64,7 +64,7 @@ defmodule ManagerTest do
   test "Closespider itemcount is respected" do
     Process.register(self(), :spider_closed_callback_test)
     :ok = Crawly.Engine.start_spider(Manager.TestSpider)
-    Process.sleep(501)
+    Process.sleep(1_000)
     assert_receive :itemcount_limit
   end
 
@@ -72,11 +72,9 @@ defmodule ManagerTest do
     Process.register(self(), :close_by_timeout_listener)
 
     :ok = Crawly.Engine.start_spider(Manager.CloseByTimeoutSpider)
-    Process.sleep(501)
+    Process.sleep(1_000)
     assert_receive :itemcount_timeout
   end
-
-  #
 
   test "Can't start already started spider" do
     :ok = Crawly.Engine.start_spider(Manager.TestSpider)
@@ -180,8 +178,6 @@ defmodule Manager.CloseByTimeoutSpider do
 
   def override_settings() do
     on_spider_closed_callback = fn reason ->
-      IO.puts("Stopped #{reason}")
-
       case Process.whereis(:close_by_timeout_listener) do
         nil ->
           :nothing_to_do

--- a/test/request_storage_test.exs
+++ b/test/request_storage_test.exs
@@ -60,7 +60,10 @@ defmodule RequestStorageTest do
              Crawly.RequestsStorage.stats(:unkown)
 
     assert {:error, :storage_worker_not_running} ==
-             Crawly.RequestsStorage.store(%{}, :unkown)
+             Crawly.RequestsStorage.store(
+               :unkown,
+               Crawly.Utils.request_from_url("http://example.com")
+             )
   end
 
   test "Duplicated requests are filtered out", context do


### PR DESCRIPTION
Hey @Ziinc I have simplified the handle_continue function a bit (e.g. combined operations for requests and URLs). Hopefully, that looks ok to you. 