### PR TITLE
Make :logger_file_backend an opt-in dependency

### DIFF
--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -139,7 +139,7 @@ stored under the `log_dir` folder. This option is ignored if `log_to_file` is no
 
 default: false
 
-Enables or disables file logging. If set to `true`, make sure to add `:logger_file_backend` as a dependency to your project.
+Enables or disables file logging. If set to `true`, make sure to add `:logger_file_backend` https://github.com/onkel-dirtus/logger_file_backend#loggerfilebackend as a dependency to your project.
 
 ### port :: pos_integer()
 

--- a/documentation/configuration.md
+++ b/documentation/configuration.md
@@ -139,7 +139,7 @@ stored under the `log_dir` folder. This option is ignored if `log_to_file` is no
 
 default: false
 
-Enables or disables file logging.
+Enables or disables file logging. If set to `true`, make sure to add `:logger_file_backend` as a dependency to your project.
 
 ### port :: pos_integer()
 

--- a/lib/crawly/engine.ex
+++ b/lib/crawly/engine.ex
@@ -61,9 +61,15 @@ defmodule Crawly.Engine do
       |> Map.put_new_lazy(:crawl_id, &UUID.uuid1/0)
 
     # Filter all logs related to a given spider
-    case {Crawly.Utils.get_settings(:log_to_file, spider_name), Code.ensure_loaded?(LoggerFileBackend)} do
-      {true, true} -> configure_spider_logs(spider_name, opts[:crawl_id])
-      {true, false} -> Logger.warn(":logger_file_backend must be installed as a peer dependency if log_to_file config is set to true")
+    case {Crawly.Utils.get_settings(:log_to_file, spider_name),
+          Code.ensure_loaded?(LoggerFileBackend)} do
+      {true, true} ->
+        configure_spider_logs(spider_name, opts[:crawl_id])
+
+      {true, false} ->
+        Logger.warn(
+          ":logger_file_backend must be installed as a peer dependency if log_to_file config is set to true"
+        )
     end
 
     GenServer.call(

--- a/lib/crawly/engine.ex
+++ b/lib/crawly/engine.ex
@@ -70,6 +70,7 @@ defmodule Crawly.Engine do
         Logger.warn(
           ":logger_file_backend https://github.com/onkel-dirtus/logger_file_backend#loggerfilebackend must be installed as a peer dependency if log_to_file config is set to true"
         )
+
       _ ->
         false
     end

--- a/lib/crawly/engine.ex
+++ b/lib/crawly/engine.ex
@@ -243,31 +243,33 @@ defmodule Crawly.Engine do
   end
 
   defp configure_spider_logs(spider_name, crawl_id) do
-    log_dir =
-      Crawly.Utils.get_settings(
-        :log_dir,
-        spider_name,
-        System.tmp_dir()
+    if Code.ensure_loaded?(LoggerFileBackend) do
+      log_dir =
+        Crawly.Utils.get_settings(
+          :log_dir,
+          spider_name,
+          System.tmp_dir()
+        )
+
+      current_unix_timestamp = :os.system_time(:second)
+
+      Logger.add_backend({LoggerFileBackend, :debug})
+
+      log_file_path =
+        Path.join([
+          log_dir,
+          inspect(spider_name),
+          # underscore separates the timestamp and the crawl_id
+          inspect(current_unix_timestamp) <> "_" <> crawl_id
+        ]) <> ".log"
+
+      Logger.configure_backend({LoggerFileBackend, :debug},
+        path: log_file_path,
+        level: :debug,
+        metadata_filter: [crawl_id: crawl_id]
       )
 
-    current_unix_timestamp = :os.system_time(:second)
-
-    Logger.add_backend({LoggerFileBackend, :debug})
-
-    log_file_path =
-      Path.join([
-        log_dir,
-        inspect(spider_name),
-        # underscore separates the timestamp and the crawl_id
-        inspect(current_unix_timestamp) <> "_" <> crawl_id
-      ]) <> ".log"
-
-    Logger.configure_backend({LoggerFileBackend, :debug},
-      path: log_file_path,
-      level: :debug,
-      metadata_filter: [crawl_id: crawl_id]
-    )
-
-    Logger.debug("Writing logs to #{log_file_path}")
+      Logger.debug("Writing logs to #{log_file_path}")
+    end
   end
 end

--- a/lib/crawly/engine.ex
+++ b/lib/crawly/engine.ex
@@ -62,7 +62,7 @@ defmodule Crawly.Engine do
 
     # Filter all logs related to a given spider
     case {Crawly.Utils.get_settings(:log_to_file, spider_name),
-          Code.ensure_loaded?(LoggerFileBackend)} do
+          Crawly.Utils.ensure_loaded?(LoggerFileBackend)} do
       {true, true} ->
         configure_spider_logs(spider_name, opts[:crawl_id])
 

--- a/lib/crawly/engine.ex
+++ b/lib/crawly/engine.ex
@@ -68,8 +68,10 @@ defmodule Crawly.Engine do
 
       {true, false} ->
         Logger.warn(
-          ":logger_file_backend must be installed as a peer dependency if log_to_file config is set to true"
+          ":logger_file_backend https://github.com/onkel-dirtus/logger_file_backend#loggerfilebackend must be installed as a peer dependency if log_to_file config is set to true"
         )
+      _ ->
+        false
     end
 
     GenServer.call(

--- a/lib/crawly/engine.ex
+++ b/lib/crawly/engine.ex
@@ -63,7 +63,7 @@ defmodule Crawly.Engine do
     # Filter all logs related to a given spider
     case {Crawly.Utils.get_settings(:log_to_file, spider_name), Code.ensure_loaded?(LoggerFileBackend)} do
       {true, true} -> configure_spider_logs(spider_name, opts[:crawl_id])
-      {true, false} -> Logger.warn(":logger_file_backend should be installed as a peer dependency if log_to_file config is set to true")
+      {true, false} -> Logger.warn(":logger_file_backend must be installed as a peer dependency if log_to_file config is set to true")
     end
 
     GenServer.call(

--- a/lib/crawly/utils.ex
+++ b/lib/crawly/utils.ex
@@ -207,4 +207,12 @@ defmodule Crawly.Utils do
       end
     end)
   end
+
+  @doc """
+  Wrapper function for Code.ensure_loaded?/1 to allow mocking
+  """
+  @spec ensure_loaded?(atom) :: boolean
+  def ensure_loaded? (module) do
+    Code.ensure_loaded?(module)
+  end
 end

--- a/lib/crawly/utils.ex
+++ b/lib/crawly/utils.ex
@@ -212,7 +212,7 @@ defmodule Crawly.Utils do
   Wrapper function for Code.ensure_loaded?/1 to allow mocking
   """
   @spec ensure_loaded?(atom) :: boolean
-  def ensure_loaded? (module) do
+  def ensure_loaded?(module) do
     Code.ensure_loaded?(module)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -73,7 +73,7 @@ defmodule Crawly.Mixfile do
       {:earmark, "~> 1.2", only: :dev},
       {:meck, "~> 0.9", only: :test},
       {:excoveralls, "~> 0.10", only: :test},
-      {:logger_file_backend, "~> 0.0.11"}
+      {:logger_file_backend, "~> 0.0.11", only: [:test, :dev]}
     ]
   end
 


### PR DESCRIPTION
- Made :logger_file_backend an opt-in-dependency
- Only configure `LoggerFileBackend` if module is loaded